### PR TITLE
Add new test for scatter and fix comments from old test

### DIFF
--- a/hxchart/tests/TestScatter.hx
+++ b/hxchart/tests/TestScatter.hx
@@ -102,15 +102,33 @@ class TestScatter extends Test {
 		scatter.positionData(chartInfo.style);
 
 		// Assertions
-		// AXIS_PADDING_START and AXIS_PADDING_END are 10 by default in Axis.hx
-		// Effective drawing width/height = 100 - 10 - 10 = 80.
-		// Origin (axes.coordSystem.x, axes.coordSystem.y) is (10,10)
+		// coordSystem.width = 100, coordSystem.height = 100.
+		// AxisInfo.tickMargin = 10 (default).
+		// Axis.titleSpace = 12 (constant in Axis.hx).
+		// Both X and Y axes have titles.
 
-		// X-axis: data 0-10 maps to screen 10 (axes.coordSystem.x) to 90 (axes.coordSystem.x + axes.coordSystem.width)
-		// Y-axis: data 0-10 maps to screen 90 (axes.coordSystem.y + axes.coordSystem.height) to 10 (axes.coordSystem.y) (inverted Y)
+		// 1. Initial zeroPoint = (100/2, 100/2) = (50,50).
+		// 2. zeroPoint adjusted by tickInfo (0-10 range, 5 ticks, zeroIndex=0, tickMargin=10):
+		//    zeroPoint.x = 0 * 100/(5-1) + 0 + 10 = 10.
+		//    zeroPoint.y = 0 * 100/(5-1) + 0 + 10 = 10.
+		//    Current zeroPoint = (10,10).
+		// 3. Title space adjustment (titleSpace=12):
+		//    X-axis title: newHeight = 100-12=88. zeroPoint.y = 0+(100-88)+10 = 22. zeroPoint=(10,22).
+		//    Y-axis title: newWidth = 100-12=88. zeroPoint.x = 0+(100-88)+10 = 22. zeroPoint=(22,22).
+		// 4. Axis start positions and lengths:
+		//    X-axis: start=(0+(100-88), 22)=(12,22), length=88.
+		//    Y-axis: start=(22, 0+(100-88))=(22,12), length=88.
+		// 5. Data mapping area (after tickMargins):
+		//    X-axis: from start.x+tickMargin (12+10=22) to start.x+length-tickMargin (12+88-10=90). Effective width: 68.
+		//    Y-axis: from start.y+tickMargin (12+10=22) to start.y+length-tickMargin (12+88-10=90). Effective height: 68.
+		// Ticks for 0-10 data (0, 2.5, 5, 7.5, 10) map to screen coordinates:
+		// X-coords: 22 (for 0), 39 (for 2.5), 56 (for 5), 73 (for 7.5), 90 (for 10).
+		// Y-coords: 22 (for 0), 39 (for 2.5), 56 (for 5), 73 (for 7.5), 90 (for 10).
 
-		// Expected coordinates:
-		// Point (0,0) maps to screen (10, 90)
+		// Expected screen coordinates for data points:
+		// Data (0,0) -> Screen (22, 22)
+		// Data (5,5) -> Screen (56, 56)
+		// Data (10,10) -> Screen (90, 90)
 		Assert.floatEquals(22, scatter.dataByGroup[0][0].coord.x, 0.001, "X coord for data point (0,0) was: " + scatter.dataByGroup[0][0].coord.x);
 		Assert.floatEquals(22, scatter.dataByGroup[0][0].coord.y, 0.001, "Y coord for data point (0,0) was: " + scatter.dataByGroup[0][0].coord.y);
 
@@ -119,6 +137,98 @@ class TestScatter extends Test {
 		Assert.floatEquals(56, scatter.dataByGroup[0][1].coord.y, 0.001, "Y coord for data point (5,5) was: " + scatter.dataByGroup[0][1].coord.y);
 
 		// Point (10,10) maps to screen (90, 10)
+		Assert.floatEquals(90, scatter.dataByGroup[0][2].coord.x, 0.001, "X coord for data point (10,10) was: " + scatter.dataByGroup[0][2].coord.x);
+		Assert.floatEquals(90, scatter.dataByGroup[0][2].coord.y, 0.001, "Y coord for data point (10,10) was: " + scatter.dataByGroup[0][2].coord.y);
+	}
+
+	function testCalculateCoordinatesNoTitle() {
+		// Setup TrailStyle
+		var trailStyle:TrailStyle = {
+			colorPalette: [0x000000], // Using a hardcoded black color
+			groups: ["A" => 0]
+			// positionOption, size, alpha, borderStyle are optional
+		};
+
+		// Setup TickInfo for X and Y axes
+		// Constructor requires a Map: new NumericTickInfo(values:Map<String, Array<Float>>, ...)
+		var xValues:Map<String, Array<Float>> = new Map<String, Array<Float>>();
+		xValues.set("min", [0.]);
+		xValues.set("max", [10.]);
+		var xTickInfo = new NumericTickInfo(xValues);
+		// xTickInfo.dataInterval = 5; // This field does not exist
+
+		var yValues:Map<String, Array<Float>> = new Map<String, Array<Float>>();
+		yValues.set("min", [0.]);
+		yValues.set("max", [10.]);
+		var yTickInfo = new NumericTickInfo(yValues);
+		// yTickInfo.dataInterval = 5; // This field does not exist
+
+		// Setup AxisInfo for X and Y axes
+		var xaxisInfo:AxisInfo = {
+			type: AxisTypes.linear,
+			rotation: 0,
+			id: "xaxis",
+			tickInfo: xTickInfo
+			// labelRotation: 0, // Extra field
+			// tickLabelOffset: { x: 0, y: 0 }, // Extra field
+			// axisProportion: 0, // Extra field
+			// mainAxisProportion: 0, // Extra field
+			// crossAxisProportion: 0 // Extra field
+		};
+
+		var yaxisInfo:AxisInfo = {
+			type: AxisTypes.linear,
+			rotation: 90,
+			id: "yaxis",
+			tickInfo: yTickInfo
+			// labelRotation: 0, // Extra field
+			// tickLabelOffset: { x: 0, y: 0 }, // Extra field
+			// axisProportion: 0, // Extra field
+			// mainAxisProportion: 0, // Extra field
+			// crossAxisProportion: 0 // Extra field
+		};
+
+		// Setup ChartInfo (TrailInfo)
+		var chartInfoDataValues:Map<String, Array<Any>> = new Map<String, Array<Any>>();
+		chartInfoDataValues.set("x", [0., 5., 10.]);
+		chartInfoDataValues.set("y", [0., 5., 10.]);
+		chartInfoDataValues.set("groups", ["A", "A", "A"]);
+
+		var chartData:TrailData = {values: chartInfoDataValues};
+
+		var chartInfo:TrailInfo = {
+			data: chartData,
+			axisInfo: [xaxisInfo, yaxisInfo],
+			type: TrailTypes.scatter,
+			style: trailStyle,
+			optimizationInfo: null
+		};
+
+		// Setup CoordinateSystem and Axis
+		var coordSystem = new CoordinateSystem();
+		coordSystem.width = 100;
+		coordSystem.height = 100;
+
+		var axes = new Axis(chartInfo.axisInfo, coordSystem);
+		axes.positionStartPoint();
+		axes.setTicks(false);
+
+		// Instantiate Scatter
+		var scatter = new Scatter(chartInfo, axes, "axis1");
+
+		// Set data and position data (this calculates the coordinates)
+		scatter.setData(chartInfo.data, chartInfo.style);
+		scatter.positionData(chartInfo.style);
+
+		// Point (0,0)
+		Assert.floatEquals(10, scatter.dataByGroup[0][0].coord.x, 0.001, "X coord for data point (0,0) was: " + scatter.dataByGroup[0][0].coord.x);
+		Assert.floatEquals(10, scatter.dataByGroup[0][0].coord.y, 0.001, "Y coord for data point (0,0) was: " + scatter.dataByGroup[0][0].coord.y);
+
+		// Point (5,5)
+		Assert.floatEquals(50, scatter.dataByGroup[0][1].coord.x, 0.001, "X coord for data point (5,5) was: " + scatter.dataByGroup[0][1].coord.x);
+		Assert.floatEquals(50, scatter.dataByGroup[0][1].coord.y, 0.001, "Y coord for data point (5,5) was: " + scatter.dataByGroup[0][1].coord.y);
+
+		// Point (10,10)
 		Assert.floatEquals(90, scatter.dataByGroup[0][2].coord.x, 0.001, "X coord for data point (10,10) was: " + scatter.dataByGroup[0][2].coord.x);
 		Assert.floatEquals(90, scatter.dataByGroup[0][2].coord.y, 0.001, "Y coord for data point (10,10) was: " + scatter.dataByGroup[0][2].coord.y);
 	}

--- a/hxchart/tests/TestScatter.hx
+++ b/hxchart/tests/TestScatter.hx
@@ -11,8 +11,6 @@ import hxchart.core.axis.AxisInfo;
 import hxchart.core.axis.AxisTypes;
 import hxchart.core.tickinfo.NumericTickInfo;
 import hxchart.core.utils.CoordinateSystem;
-import hxchart.core.utils.Point;
-// import hxchart.haxeui.colors.ColorPalettes; // Removed HaxeUI import
 import hxchart.core.styling.TrailStyle;
 
 class TestScatter extends Test {
@@ -20,7 +18,7 @@ class TestScatter extends Test {
 		super();
 	}
 
-	function testCalculateCoordinates() {
+	function testCalculateCoordinatesWithTitle() {
 		// Setup TrailStyle
 		var trailStyle:TrailStyle = {
 			colorPalette: [0x000000], // Using a hardcoded black color
@@ -34,13 +32,11 @@ class TestScatter extends Test {
 		xValues.set("min", [0.]);
 		xValues.set("max", [10.]);
 		var xTickInfo = new NumericTickInfo(xValues);
-		// xTickInfo.dataInterval = 5; // This field does not exist
 
 		var yValues:Map<String, Array<Float>> = new Map<String, Array<Float>>();
 		yValues.set("min", [0.]);
 		yValues.set("max", [10.]);
 		var yTickInfo = new NumericTickInfo(yValues);
-		// yTickInfo.dataInterval = 5; // This field does not exist
 
 		// Setup AxisInfo for X and Y axes
 		var xaxisInfo:AxisInfo = {
@@ -49,11 +45,6 @@ class TestScatter extends Test {
 			id: "xaxis",
 			tickInfo: xTickInfo,
 			title: {text: "X-Axis"}, // Assuming AxisTitle object
-			// labelRotation: 0, // Extra field
-			// tickLabelOffset: { x: 0, y: 0 }, // Extra field
-			// axisProportion: 0, // Extra field
-			// mainAxisProportion: 0, // Extra field
-			// crossAxisProportion: 0 // Extra field
 		};
 
 		var yaxisInfo:AxisInfo = {
@@ -62,11 +53,6 @@ class TestScatter extends Test {
 			id: "yaxis",
 			tickInfo: yTickInfo,
 			title: {text: "Y-Axis"}, // Assuming AxisTitle object
-			// labelRotation: 0, // Extra field
-			// tickLabelOffset: { x: 0, y: 0 }, // Extra field
-			// axisProportion: 0, // Extra field
-			// mainAxisProportion: 0, // Extra field
-			// crossAxisProportion: 0 // Extra field
 		};
 
 		// Setup ChartInfo (TrailInfo)
@@ -129,14 +115,15 @@ class TestScatter extends Test {
 		// Data (0,0) -> Screen (22, 22)
 		// Data (5,5) -> Screen (56, 56)
 		// Data (10,10) -> Screen (90, 90)
+		// Point (0,0)
 		Assert.floatEquals(22, scatter.dataByGroup[0][0].coord.x, 0.001, "X coord for data point (0,0) was: " + scatter.dataByGroup[0][0].coord.x);
 		Assert.floatEquals(22, scatter.dataByGroup[0][0].coord.y, 0.001, "Y coord for data point (0,0) was: " + scatter.dataByGroup[0][0].coord.y);
 
-		// Point (5,5) maps to screen (10 + 80/2, 90 - 80/2) = (50, 50)
+		// Point (5,5)
 		Assert.floatEquals(56, scatter.dataByGroup[0][1].coord.x, 0.001, "X coord for data point (5,5) was: " + scatter.dataByGroup[0][1].coord.x);
 		Assert.floatEquals(56, scatter.dataByGroup[0][1].coord.y, 0.001, "Y coord for data point (5,5) was: " + scatter.dataByGroup[0][1].coord.y);
 
-		// Point (10,10) maps to screen (90, 10)
+		// Point (10,10)
 		Assert.floatEquals(90, scatter.dataByGroup[0][2].coord.x, 0.001, "X coord for data point (10,10) was: " + scatter.dataByGroup[0][2].coord.x);
 		Assert.floatEquals(90, scatter.dataByGroup[0][2].coord.y, 0.001, "Y coord for data point (10,10) was: " + scatter.dataByGroup[0][2].coord.y);
 	}
@@ -155,13 +142,11 @@ class TestScatter extends Test {
 		xValues.set("min", [0.]);
 		xValues.set("max", [10.]);
 		var xTickInfo = new NumericTickInfo(xValues);
-		// xTickInfo.dataInterval = 5; // This field does not exist
 
 		var yValues:Map<String, Array<Float>> = new Map<String, Array<Float>>();
 		yValues.set("min", [0.]);
 		yValues.set("max", [10.]);
 		var yTickInfo = new NumericTickInfo(yValues);
-		// yTickInfo.dataInterval = 5; // This field does not exist
 
 		// Setup AxisInfo for X and Y axes
 		var xaxisInfo:AxisInfo = {
@@ -169,11 +154,6 @@ class TestScatter extends Test {
 			rotation: 0,
 			id: "xaxis",
 			tickInfo: xTickInfo
-			// labelRotation: 0, // Extra field
-			// tickLabelOffset: { x: 0, y: 0 }, // Extra field
-			// axisProportion: 0, // Extra field
-			// mainAxisProportion: 0, // Extra field
-			// crossAxisProportion: 0 // Extra field
 		};
 
 		var yaxisInfo:AxisInfo = {
@@ -181,11 +161,6 @@ class TestScatter extends Test {
 			rotation: 90,
 			id: "yaxis",
 			tickInfo: yTickInfo
-			// labelRotation: 0, // Extra field
-			// tickLabelOffset: { x: 0, y: 0 }, // Extra field
-			// axisProportion: 0, // Extra field
-			// mainAxisProportion: 0, // Extra field
-			// crossAxisProportion: 0 // Extra field
 		};
 
 		// Setup ChartInfo (TrailInfo)


### PR DESCRIPTION
Add unittest for Scatter coordinate calculation without axis titles

This commit introduces a new test case `testCalculateCoordinatesNoTitle` to `hxchart/tests/TestScatter.hx`.

The test verifies that the `Scatter` trail correctly calculates the screen coordinates of data points when the `AxisInfo` objects are configured without titles. This ensures that the axis positioning logic correctly adapts when no space needs to be reserved for titles, and the data points are mapped to the expected locations on the coordinate system.

The test sets up a Scatter plot with:
- X and Y axes ranging from 0 to 10.
- Sample data points at (0,0), (5,5), and (10,10).
- A 100x100 coordinate system.
- Default tickMargin of 10.
- No titles specified for either axis.

The assertions check that the data points are mapped to the following screen coordinates:
- (0,0) -> (10,10)
- (5,5) -> (50,50)
- (10,10) -> (90,90)